### PR TITLE
Added ability to only paste the command in ghostty without running it

### DIFF
--- a/GhosttyAlfred.applescript
+++ b/GhosttyAlfred.applescript
@@ -4,6 +4,8 @@
 
 -- tab : t | window: n | split: d
 property open_new : "t"
+-- yes : y | no: n
+property run_cmd : "y"
 property reuse_tab : false
 property timeout_seconds : 3
 property shell_load_delay : 1.0 -- Delay for session to load
@@ -108,8 +110,10 @@ on send(a_command, just_activated)
 	tell application "System Events"
 		tell process "Ghostty"
 			keystroke "v" using command down
-			delay 0.1
-			keystroke return
+			if run_cmd is "y"
+				delay 0.1
+				keystroke return
+			end if
 		end tell
 	end tell
 	

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ AppleScript to integrate [Ghostty](https://ghostty.org/) with [Alfred](https://w
   * <kbd>t</kbd> open new tab
   * <kbd>n</kbd> open new window
   * <kbd>d</kbd> open new split
+- `run_cmd` : either <kbd>y</kbd> or <kbd>n</kbd>
+  * <kbd>y</kbd> paste and run the command in `ghostty`
+  * <kbd>n</kbd> only paste the command, do not run it
 - `reuse_tab` : either `true` or `false` 
 - `timeout_seconds`
 - `shell_load_delay`


### PR DESCRIPTION
Hey @zeitlings, thanks for the amazing script!
I am a relatively recent `ghostty` convert and I am trying to switch all my tools to use it because it has quickly become my favourite terminal emulator 👻
Your script has made getting it working with Alfred a breeze! However, for ages I have had the terminal feature in Alfred to just paste the command and not run it. That is because I am sometimes a _silly goose_ and I'd rather always double-check what I am about to run within the terminal.
I figured I my not be the only one doing this, so I made a PR after implementing it for myself in the off-chance that it might be useful to others!
If this is not welcome or you do not want to deal with external PRs, please feel free to close it, or give feedback if you'd prefer things implemented differently!
Thanks again for the great script! :)